### PR TITLE
Minor compose and envs fixes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,19 +5,18 @@ services:
         - BOT_TOKEN=${BOT_TOKEN}
         - DB_USER=${DB_USER}
         - DB_HOST=database
-        - DP_PORT=${DB_PORT}
+        - DB_PORT=5432
         - DB_USER_PASSWORD=${DB_USER_PASSWORD}
         - DB_NAME=${DB_NAME}
       depends_on:
         database:
           condition: service_healthy
-#      command: sh -c ". .venv/bin/activate && sleep 600"
       command: sh -c ". .venv/bin/activate && python -m good_advice_bot"
 
   database:
     image: postgres:16.4-bookworm
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -d ${DB_NAME} -U ${DB_USER}"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -26,6 +25,8 @@ services:
       - POSTGRES_USER=${DB_USER}
       - POSTGRES_PASSWORD=${DB_USER_PASSWORD}
       - POSTGRES_DB=${DB_NAME}
+    ports:
+        - "${DB_PORT}:5432"
     volumes:
       - goodbot_postgres_data:/var/lib/postgresql/data
 

--- a/good_advice_bot/__init__.py
+++ b/good_advice_bot/__init__.py
@@ -1,3 +1,0 @@
-from dotenv import load_dotenv
-
-load_dotenv()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 aiogram~=3.12.0
 asyncpg~=0.29.0
-python-dotenv~=1.0.1


### PR DESCRIPTION
- map postgres ports so it could be accessible across internet (it's easier to work with the db with DataGrip then psql)
- change healch-check since we now have a user with not a default name
- get rid of load_env() because anyway we load envs from .env with docker compose