### PR TITLE
Restart containers only on failure

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
         database:
           condition: service_healthy
       command: sh -c ". .venv/bin/activate && python -m get_random_note_bot"
-      restart: always
+      restart: on-failure
 
   database:
     image: postgres:16.4-bookworm


### PR DESCRIPTION
- because if you specify 'always', docker demon will start containers when you boot your OS even if you stopped the containers before